### PR TITLE
Fix leaking commandlist in imgui plugin on D3D12 on shutdown.

### DIFF
--- a/source/plugins/sl.imgui/imguiEntry.cpp
+++ b/source/plugins/sl.imgui/imguiEntry.cpp
@@ -427,6 +427,12 @@ void destroyContext(Context* ctx)
         SL_SAFE_RELEASE(pluginCtx.pd3dSrvDescHeap);
     }
 
+    if (pluginCtx.cmdList != nullptr)
+    {
+        pluginCtx.compute->destroyCommandListContext(pluginCtx.cmdList);
+    }
+    pluginCtx.cmdList = nullptr;
+
     ImGui_ImplWin32_Shutdown();
 
     ImGui::DestroyContext(g_ctx->imgui);


### PR DESCRIPTION
On exit, the commandlist allocated by the imgui plugin is not destroyed. This causes dangling refs to the ID3D12 CommandList, CommandAllocator, Fence and CommandQueue.