### PR TITLE
D3D12 - Ensure buffers are always created in the "Common" resource state

### DIFF
--- a/source/platforms/sl.chi/d3d12.cpp
+++ b/source/platforms/sl.chi/d3d12.cpp
@@ -2046,7 +2046,6 @@ ComputeStatus D3D12::createBufferResourceImpl(ResourceDescription &resourceDesc,
             break;
         case eHeapTypeUpload:
             bufferDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-            initialState |= ResourceState::eGenericRead; // Keep validation layer happy when creating NGX resources
             break;
         case eHeapTypeReadback:
             bufferDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
@@ -2055,7 +2054,8 @@ ComputeStatus D3D12::createBufferResourceImpl(ResourceDescription &resourceDesc,
 
     D3D12_HEAP_TYPE NativeHeapType = (D3D12_HEAP_TYPE) resourceDesc.heapType; // TODO : proper conversion !
 
-    D3D12_RESOURCE_STATES NativeInitialState = toD3D12States(initialState);
+    // Buffers must always be created in Common state
+    D3D12_RESOURCE_STATES NativeInitialState = D3D12_RESOURCE_STATE_COMMON;
 
     CD3DX12_HEAP_PROPERTIES heapProp(NativeHeapType, resourceDesc.creationMask, resourceDesc.visibilityMask ? resourceDesc.visibilityMask : m_visibleNodeMask);
 


### PR DESCRIPTION
Fixes the following D3D12 Debug Layer warning saying initial states other than common on Buffers are ignored.

```
D3D12 WARNING: ID3D12Device::CreateCommittedResource: Ignoring InitialState D3D12_RESOURCE_STATE_COPY_DEST. Buffers are effectively created in state D3D12_RESOURCE_STATE_COMMON. [ STATE_CREATION WARNING #1328: CREATERESOURCE_STATE_IGNORED]
```

This can be reproduced when using DLSS