### PR TITLE
Add <chrono> include to extra.h to fix compile when retargeting to recent Windows SDK versions

### DIFF
--- a/source/core/sl.extra/extra.h
+++ b/source/core/sl.extra/extra.h
@@ -38,6 +38,7 @@
 #include <locale>
 #include <iomanip>
 #include <array>
+#include <chrono>
 
 #ifdef SL_WINDOWS
 #define SL_IGNOREWARNING_PUSH __pragma(warning(push))


### PR DESCRIPTION
On newer Windows SDK versions (10.0.26100, for example), something has changed with how #include directives are handled, and source/core/sl.extra/extra.h no longer compiles when the project is re-targeted. The solution is to explicitly include <chrono>.