### PR TITLE
Fix mismatched declaration of 'AbiValidation'

### DIFF
--- a/include/sl_core_types.h
+++ b/include/sl_core_types.h
@@ -584,7 +584,7 @@ SL_STRUCT_BEGIN(ViewportHandle, StructType({ 0x171b6435, 0x9b3c, 0x4fc8, { 0x99,
     operator uint32_t() const { return value; }
 private:
     uint32_t value = UINT_MAX;
-    friend void sl::test::AbiValidation();
+    friend constexpr void sl::test::AbiValidation();
 SL_STRUCT_END()
 
 //! Specifies feature requirement flags


### PR DESCRIPTION
non-constexpr declaration of 'AbiValidation' in L587 follows constexpr declaration in L62

Fixes #71 