### PR TITLE
Add Qualcomm Vendor IDs

### DIFF
--- a/source/platforms/sl.chi/compute.h
+++ b/source/platforms/sl.chi/compute.h
@@ -529,6 +529,8 @@ enum class VendorId : uint32_t
     eNVDA = 0x10DE,
     eAMD = 0x1002,
     eIntel = 0x8086,
+    eQualcommACPI = 0x4D4F4351,
+    eQualcommPCI = 0x0571,
 };
 
 inline bool isVendorNvidia(VendorId id)
@@ -536,6 +538,10 @@ inline bool isVendorNvidia(VendorId id)
     return id == VendorId::eNVDA;
 }
 
+inline bool isVendorQualcomm(VendorId id)
+{
+    return (id == VendorId::eQualcommACPI) || (id == VendorId::eQualcommPCI);
+}
 
 enum FenceFlags : uint32_t
 {

--- a/source/plugins/sl.common/commonInterface.cpp
+++ b/source/plugins/sl.common/commonInterface.cpp
@@ -202,7 +202,7 @@ bool getSystemCaps(common::SystemCaps*& info)
             DXGI_ADAPTER_DESC desc;
             if (SUCCEEDED(adapter->GetDesc(&desc)))
             {
-                // Intel, AMD or NVIDIA physical GPUs only
+                // Intel, AMD, Qulacomm or NVIDIA physical GPUs only
                 auto vendor = (chi::VendorId)desc.VendorId;
                 
 #ifndef SL_PRODUCTION
@@ -213,7 +213,7 @@ bool getSystemCaps(common::SystemCaps*& info)
                 }
 #endif
 
-                if (isVendorNvidia(vendor) || vendor == chi::VendorId::eIntel || vendor == chi::VendorId::eAMD)
+                if (isVendorNvidia(vendor) || isVendorQualcomm(vendor) || vendor == chi::VendorId::eIntel || vendor == chi::VendorId::eAMD)
                 {
                     info->adapters[info->gpuCount].nativeInterface = adapter;
                     info->adapters[info->gpuCount].vendor = vendor;


### PR DESCRIPTION
Streamline is currently failing to initialize on Windows devices with Qualcomm GPUs, where `slInit` is returning `eErrorNoPlugins` due to an unrecognized vendor ID.

This change adds the vendor IDs for Qualcomm's Adreno GPUs. Qualcomm's GPU is currently attached to the ACPI bus, with DXGI returning an ACPI ID but the Vulkan driver returning a PCI ID. Because of this, both IDs have been included.
